### PR TITLE
fix: Jekyll設定の更新とドキュメントリンクの整備

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,61 @@
+# GitHub Pages用Jekyll ビルド・デプロイワークフロー
+name: Deploy Jekyll site to Pages
+
+on:
+  # mainブランチへのプッシュ時に実行
+  push:
+    branches: ["main", "master"]
+
+  # 手動実行を可能にする
+  workflow_dispatch:
+
+# GitHub Pagesへのデプロイ権限を設定
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行制御（デプロイの重複を防ぐ）
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Jekyll サイトビルドジョブ
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1" # GitHub Pagesでサポートされているバージョン
+          bundler-cache: true # Gemfile.lockがある場合のキャッシュ
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        # bundle execを使用してJekyllをビルド
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        # ビルド成果物をアップロード
+        uses: actions/upload-pages-artifact@v3
+
+  # デプロイジョブ
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,18 @@ source 'https://rubygems.org'
 # GitHub Pages公式推奨設定
 gem 'github-pages', group: :jekyll_plugins
 
-# プラグインは_config.ymlのpluginsセクションで管理
-# jekyll-redirect-fromはgithub-pagesに含まれているため不要
+# GitHub Pagesで利用可能なプラグインは自動的に含まれる：
+# - jekyll-feed
+# - jekyll-sitemap
+# - jekyll-seo-tag
+# - jekyll-relative-links
+# - jekyll-optional-front-matter
+# - jekyll-redirect-from
+# - jekyll-default-layout
 
 # ローカル開発用（Ruby 3.0+で必要）
 gem 'webrick', '~> 1.7'
 
-# ローカル開発用パフォーマンス向上（GitHub Pagesでは非対応のため開発環境のみ）
-group :development do
-  gem 'jekyll-cache'
-end
+# Windows環境対応
+gem 'wdm', '~> 0.1.1', :platforms => [:mingw, :x64_mingw, :mswin]
+gem 'tzinfo-data', :platforms => [:mingw, :x64_mingw, :mswin, :jruby]

--- a/_config.yml
+++ b/_config.yml
@@ -14,8 +14,8 @@ author:
   name: "Development Team"
   email: "dev@example.com"
 
-# テーマ設定
-remote_theme: jekyll/minima
+# テーマ設定（GitHub Pages標準）
+# remote_theme は使用せず、GitHub Pages標準のテーマを使用
 
 # Collections設定
 collections:

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,11 @@
 # Jekyll Configuration for Development Documentation Hub
 
+# サイト基本情報
+title: "Development Documentation Hub"
+description: "プロフェッショナル開発者のための包括的ドキュメントサイト - AI活用・プロンプトエンジニアリング・IDE効率化・GitHub統合"
+url: "https://y_ohi.github.io" # 実際のGitHub PagesのURLに変更してください
+baseurl: "/docs-manager" # リポジトリ名に変更してください
+
 # GitHub Pages互換のテーマを使用（remote_theme使用）
 # theme: minima  # GitHub Pagesではremote_themeを優先
 
@@ -40,6 +46,7 @@ defaults:
 plugins:
   - jekyll-feed
   - jekyll-sitemap
+  - jekyll-seo-tag
   - jekyll-relative-links
   - jekyll-optional-front-matter
   - jekyll-redirect-from

--- a/_documents/_anthropic-prompt-engineering/index.md
+++ b/_documents/_anthropic-prompt-engineering/index.md
@@ -11,45 +11,45 @@ Claude 4を活用したプロンプトエンジニアリング技術の包括的
 ## 📚 コンテンツ一覧
 
 ### 基本概念
-- [概要]({% link _documents/_anthropic-prompt-engineering/overview.md %}) - プロンプトエンジニアリングの基礎
-- [明確で直接的な指示]({% link _documents/_anthropic-prompt-engineering/be-clear-and-direct.md %}) - 効果的な指示の書き方
+- [概要]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/overview/) - プロンプトエンジニアリングの基礎
+- [明確で直接的な指示]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/be-clear-and-direct/) - 効果的な指示の書き方
 
 ### 高度な技術
-- [思考の連鎖]({% link _documents/_anthropic-prompt-engineering/chain-of-thought.md %}) - ステップバイステップ思考
-- [プロンプト連鎖]({% link _documents/_anthropic-prompt-engineering/chain-prompts.md %}) - 複雑な作業の分割
-- [マルチショット・プロンプティング]({% link _documents/_anthropic-prompt-engineering/multishot-prompting.md %}) - 例を活用した学習
+- [思考の連鎖]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/chain-of-thought/) - ステップバイステップ思考
+- [プロンプト連鎖]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/chain-prompts/) - 複雑な作業の分割
+- [マルチショット・プロンプティング]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/multishot-prompting/) - 例を活用した学習
 
 ### 実践的な活用
-- [Claude 4 ベストプラクティス]({% link _documents/_anthropic-prompt-engineering/claude-4-best-practices.md %}) - 実務で使える技術
-- [拡張思考のコツ]({% link _documents/_anthropic-prompt-engineering/extended-thinking-tips.md %}) - 深い思考を促す方法
-- [長文コンテキストのコツ]({% link _documents/_anthropic-prompt-engineering/long-context-tips.md %}) - 大量情報の効果的処理
+- [Claude 4 ベストプラクティス]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/claude-4-best-practices/) - 実務で使える技術
+- [拡張思考のコツ]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/extended-thinking-tips/) - 深い思考を促す方法
+- [長文コンテキストのコツ]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/long-context-tips/) - 大量情報の効果的処理
 
 ### システム・構造化
-- [システムプロンプト]({% link _documents/_anthropic-prompt-engineering/system-prompts.md %}) - ベースとなる指示設計
-- [XMLタグの活用]({% link _documents/_anthropic-prompt-engineering/use-xml-tags.md %}) - 構造化された指示
-- [Claudeの回答プリフィル]({% link _documents/_anthropic-prompt-engineering/prefill-claudes-response.md %}) - 回答の誘導技術
+- [システムプロンプト]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/system-prompts/) - ベースとなる指示設計
+- [XMLタグの活用]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/use-xml-tags/) - 構造化された指示
+- [Claudeの回答プリフィル]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prefill-claudes-response/) - 回答の誘導技術
 
 ### ツール・テンプレート
-- [プロンプトテンプレートと変数]({% link _documents/_anthropic-prompt-engineering/prompt-templates-and-variables.md %}) - 再利用可能な構造
-- [プロンプト生成器]({% link _documents/_anthropic-prompt-engineering/prompt-generator.md %}) - 自動生成ツール
-- [プロンプト改善器]({% link _documents/_anthropic-prompt-engineering/prompt-improver.md %}) - 既存プロンプトの最適化
+- [プロンプトテンプレートと変数]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-templates-and-variables/) - 再利用可能な構造
+- [プロンプト生成器]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-generator/) - 自動生成ツール
+- [プロンプト改善器]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-improver/) - 既存プロンプトの最適化
 
 ## 🎯 学習パス
 
 ### 🆕 初心者向け
-1. [概要]({% link _documents/_anthropic-prompt-engineering/overview.md %}) - 基本概念の理解
-2. [明確で直接的な指示]({% link _documents/_anthropic-prompt-engineering/be-clear-and-direct.md %}) - 基本的な書き方
-3. [Claude 4 ベストプラクティス]({% link _documents/_anthropic-prompt-engineering/claude-4-best-practices.md %}) - 実践的な活用
+1. [概要]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/overview/) - 基本概念の理解
+2. [明確で直接的な指示]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/be-clear-and-direct/) - 基本的な書き方
+3. [Claude 4 ベストプラクティス]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/claude-4-best-practices/) - 実践的な活用
 
 ### ⚡ 中級者向け
-1. [思考の連鎖]({% link _documents/_anthropic-prompt-engineering/chain-of-thought.md %}) - 論理的思考の構築
-2. [マルチショット・プロンプティング]({% link _documents/_anthropic-prompt-engineering/multishot-prompting.md %}) - 例示による学習
-3. [XMLタグの活用]({% link _documents/_anthropic-prompt-engineering/use-xml-tags.md %}) - 構造化技術
+1. [思考の連鎖]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/chain-of-thought/) - 論理的思考の構築
+2. [マルチショット・プロンプティング]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/multishot-prompting/) - 例示による学習
+3. [XMLタグの活用]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/use-xml-tags/) - 構造化技術
 
 ### 🔧 上級者向け
-1. [プロンプト連鎖]({% link _documents/_anthropic-prompt-engineering/chain-prompts.md %}) - 複雑な作業分割
-2. [拡張思考のコツ]({% link _documents/_anthropic-prompt-engineering/extended-thinking-tips.md %}) - 深い分析技術
-3. [システムプロンプト]({% link _documents/_anthropic-prompt-engineering/system-prompts.md %}) - 高度なシステム設計
+1. [プロンプト連鎖]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/chain-prompts/) - 複雑な作業分割
+2. [拡張思考のコツ]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/extended-thinking-tips/) - 深い分析技術
+3. [システムプロンプト]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/system-prompts/) - 高度なシステム設計
 
 ## 📊 技術統計
 

--- a/_documents/_anthropic-prompt-engineering/index.md
+++ b/_documents/_anthropic-prompt-engineering/index.md
@@ -1,53 +1,81 @@
 ---
-title: Anthropic プロンプトエンジニアリング
-description: Anthropic Claude のプロンプトエンジニアリング関連ドキュメント集
-order: 0
+title: "Anthropic プロンプトエンジニアリング"
+description: "Claude 4を活用したプロンプトエンジニアリング技術の包括的ガイド"
 layout: default
 ---
 
-# Anthropic プロンプトエンジニアリング
+# 🤖 Anthropic プロンプトエンジニアリング
 
-Anthropic Claude を効果的に活用するためのプロンプトエンジニアリング技術の包括的なガイドです。
+Claude 4を活用したプロンプトエンジニアリング技術の包括的ガイドです。
 
-## ドキュメント一覧
-
-各リンクをクリックすると、Anthropic の公式ドキュメントにリダイレクトされます。
+## 📚 コンテンツ一覧
 
 ### 基本概念
-
-1. [プロンプトエンジニアリング概要](overview.html) - プロンプトエンジニアリングの基礎と概要
-2. [Claude 4 ベストプラクティス](claude-4-best-practices.html) - Claude 4 を使用する際のベストプラクティス
-
-### ツールとリソース
-
-3. [プロンプトジェネレーター](prompt-generator.html) - プロンプトを自動生成するツール
-4. [プロンプトテンプレートと変数](prompt-templates-and-variables.html) - 再利用可能なテンプレートの作成
-5. [プロンプト改善ツール](prompt-improver.html) - 既存プロンプトの改善方法
-
-### プロンプト設計の原則
-
-6. [明確で直接的な指示](be-clear-and-direct.html) - 効果的なプロンプトの書き方
-7. [マルチショットプロンプティング](multishot-prompting.html) - 複数の例を活用する手法
-8. [思考の連鎖（Chain of Thought）](chain-of-thought.html) - 段階的思考を促す技法
+- [概要]({% link _documents/_anthropic-prompt-engineering/overview.md %}) - プロンプトエンジニアリングの基礎
+- [明確で直接的な指示]({% link _documents/_anthropic-prompt-engineering/be-clear-and-direct.md %}) - 効果的な指示の書き方
 
 ### 高度な技術
+- [思考の連鎖]({% link _documents/_anthropic-prompt-engineering/chain-of-thought.md %}) - ステップバイステップ思考
+- [プロンプト連鎖]({% link _documents/_anthropic-prompt-engineering/chain-prompts.md %}) - 複雑な作業の分割
+- [マルチショット・プロンプティング]({% link _documents/_anthropic-prompt-engineering/multishot-prompting.md %}) - 例を活用した学習
 
-9. [XMLタグの使用](use-xml-tags.html) - 構造化されたプロンプトの作成
-10. [システムプロンプト](system-prompts.html) - システムレベルでの指示設定
-11. [Claudeの応答の事前入力](prefill-claudes-response.html) - 応答の開始部分を指定する方法
-12. [プロンプトチェーン](chain-prompts.html) - 複数のプロンプトを連携させる手法
+### 実践的な活用
+- [Claude 4 ベストプラクティス]({% link _documents/_anthropic-prompt-engineering/claude-4-best-practices.md %}) - 実務で使える技術
+- [拡張思考のコツ]({% link _documents/_anthropic-prompt-engineering/extended-thinking-tips.md %}) - 深い思考を促す方法
+- [長文コンテキストのコツ]({% link _documents/_anthropic-prompt-engineering/long-context-tips.md %}) - 大量情報の効果的処理
 
-### 特殊用途
+### システム・構造化
+- [システムプロンプト]({% link _documents/_anthropic-prompt-engineering/system-prompts.md %}) - ベースとなる指示設計
+- [XMLタグの活用]({% link _documents/_anthropic-prompt-engineering/use-xml-tags.md %}) - 構造化された指示
+- [Claudeの回答プリフィル]({% link _documents/_anthropic-prompt-engineering/prefill-claudes-response.md %}) - 回答の誘導技術
 
-13. [長文コンテキストのコツ](long-context-tips.html) - 大量のテキストを効果的に処理する方法
-14. [拡張思考のコツ](extended-thinking-tips.html) - より深い分析と推論を促す技術
+### ツール・テンプレート
+- [プロンプトテンプレートと変数]({% link _documents/_anthropic-prompt-engineering/prompt-templates-and-variables.md %}) - 再利用可能な構造
+- [プロンプト生成器]({% link _documents/_anthropic-prompt-engineering/prompt-generator.md %}) - 自動生成ツール
+- [プロンプト改善器]({% link _documents/_anthropic-prompt-engineering/prompt-improver.md %}) - 既存プロンプトの最適化
+
+## 🎯 学習パス
+
+### 🆕 初心者向け
+1. [概要]({% link _documents/_anthropic-prompt-engineering/overview.md %}) - 基本概念の理解
+2. [明確で直接的な指示]({% link _documents/_anthropic-prompt-engineering/be-clear-and-direct.md %}) - 基本的な書き方
+3. [Claude 4 ベストプラクティス]({% link _documents/_anthropic-prompt-engineering/claude-4-best-practices.md %}) - 実践的な活用
+
+### ⚡ 中級者向け
+1. [思考の連鎖]({% link _documents/_anthropic-prompt-engineering/chain-of-thought.md %}) - 論理的思考の構築
+2. [マルチショット・プロンプティング]({% link _documents/_anthropic-prompt-engineering/multishot-prompting.md %}) - 例示による学習
+3. [XMLタグの活用]({% link _documents/_anthropic-prompt-engineering/use-xml-tags.md %}) - 構造化技術
+
+### 🔧 上級者向け
+1. [プロンプト連鎖]({% link _documents/_anthropic-prompt-engineering/chain-prompts.md %}) - 複雑な作業分割
+2. [拡張思考のコツ]({% link _documents/_anthropic-prompt-engineering/extended-thinking-tips.md %}) - 深い分析技術
+3. [システムプロンプト]({% link _documents/_anthropic-prompt-engineering/system-prompts.md %}) - 高度なシステム設計
+
+## 📊 技術統計
+
+| カテゴリ       | ドキュメント数 | 主要機能                               |
+| -------------- | -------------- | -------------------------------------- |
+| **基本概念**   | 2ファイル      | 基礎理解・明確な指示                   |
+| **高度技術**   | 3ファイル      | 思考連鎖・連続処理・例示学習           |
+| **実践活用**   | 3ファイル      | ベストプラクティス・深い思考・長文処理 |
+| **システム化** | 3ファイル      | システム設計・構造化・回答制御         |
+| **ツール**     | 3ファイル      | テンプレート・生成器・改善器           |
+
+**総計**: **14ドキュメント** でプロンプトエンジニアリングを体系的にカバー
+
+## 🚀 クイックスタート
+
+```markdown
+1. 基本概念の理解
+   概要 → 明確な指示 → 基本的な活用
+
+2. 実践的な技術習得
+   思考の連鎖 → 例示学習 → 構造化技術
+
+3. 高度な活用
+   複雑作業分割 → 深い思考 → システム設計
+```
 
 ---
 
-**注意**: 上記のリンクは全て Anthropic の公式ドキュメントへのリダイレクトです。最新の情報については、直接公式サイトをご確認ください。
-
-## 関連リンク
-
-- [Anthropic 公式サイト](https://www.anthropic.com/)
-- [Claude API ドキュメント](https://docs.anthropic.com/en/api)
-- [Claude コンソール](https://console.anthropic.com/)
+**🎯 目標**: この包括的なガイドを通じて、Claude 4を活用した効果的なプロンプトエンジニアリング技術をマスターできることを目指しています。

--- a/_documents/advanced-feature.md
+++ b/_documents/advanced-feature.md
@@ -17,5 +17,5 @@ order: 2
 
 ## 参考リンク
 
-- [はじめに]({% link _documents/getting-started.md %})
+- [はじめに]({{ site.baseurl }}/documents/getting-started/)
 - [GitHub Pages公式ドキュメント](https://docs.github.com/ja/pages)

--- a/_documents/getting-started.md
+++ b/_documents/getting-started.md
@@ -17,4 +17,4 @@ order: 1
 
 ## 次のステップ
 
-[高度な機能]({% link _documents/advanced-feature.md %})についても確認してください。
+[高度な機能]({{ site.baseurl }}/documents/advanced-feature/)についても確認してください。

--- a/_documents/site-map.md
+++ b/_documents/site-map.md
@@ -22,179 +22,179 @@ layout: default
 
 ## 🤖 **Anthropic プロンプトエンジニアリング**
 
-### [📁 セクション概要]({% link _documents/_anthropic-prompt-engineering/index.md %})
+### [📁 セクション概要]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/)
 
 #### 基本概念
-- [プロンプトエンジニアリング概要]({% link _documents/_anthropic-prompt-engineering/overview.md %})
-- [Claude 4 ベストプラクティス]({% link _documents/_anthropic-prompt-engineering/claude-4-best-practices.md %})
+- [プロンプトエンジニアリング概要]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/overview/)
+- [Claude 4 ベストプラクティス]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/claude-4-best-practices/)
 
 #### ツール・リソース
-- [プロンプトジェネレーター]({% link _documents/_anthropic-prompt-engineering/prompt-generator.md %})
-- [プロンプトテンプレートと変数]({% link _documents/_anthropic-prompt-engineering/prompt-templates-and-variables.md %})
-- [プロンプト改善ツール]({% link _documents/_anthropic-prompt-engineering/prompt-improver.md %})
+- [プロンプトジェネレーター]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-generator/)
+- [プロンプトテンプレートと変数]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-templates-and-variables/)
+- [プロンプト改善ツール]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-improver/)
 
 #### 設計原則
-- [明確で直接的な指示]({% link _documents/_anthropic-prompt-engineering/be-clear-and-direct.md %})
-- [マルチショットプロンプティング]({% link _documents/_anthropic-prompt-engineering/multishot-prompting.md %})
-- [思考の連鎖（Chain of Thought）]({% link _documents/_anthropic-prompt-engineering/chain-of-thought.md %})
+- [明確で直接的な指示]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/be-clear-and-direct/)
+- [マルチショットプロンプティング]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/multishot-prompting/)
+- [思考の連鎖（Chain of Thought）]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/chain-of-thought/)
 
 #### 高度な技術
-- [XMLタグの使用]({% link _documents/_anthropic-prompt-engineering/use-xml-tags.md %})
-- [システムプロンプト]({% link _documents/_anthropic-prompt-engineering/system-prompts.md %})
-- [Claudeの応答の事前入力]({% link _documents/_anthropic-prompt-engineering/prefill-claudes-response.md %})
-- [プロンプトチェーン]({% link _documents/_anthropic-prompt-engineering/chain-prompts.md %})
+- [XMLタグの使用]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/use-xml-tags/)
+- [システムプロンプト]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/system-prompts/)
+- [Claudeの応答の事前入力]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prefill-claudes-response/)
+- [プロンプトチェーン]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/chain-prompts/)
 
 #### 特殊用途
-- [長文コンテキストのコツ]({% link _documents/_anthropic-prompt-engineering/long-context-tips.md %})
-- [拡張思考のコツ]({% link _documents/_anthropic-prompt-engineering/extended-thinking-tips.md %})
+- [長文コンテキストのコツ]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/long-context-tips/)
+- [拡張思考のコツ]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/extended-thinking-tips/)
 
 ---
 
 ## 💻 **Claude Code Documentation**
 
-### [📁 セクション概要]({% link _documents/_claude-code/index.md %})
+### [📁 セクション概要]({{ site.baseurl }}/documents/_claude-code/index/)
 
 #### 基本設定・開始
-- [CLI リファレンス]({% link _documents/_claude-code/cli-reference.md %})
-- [設定]({% link _documents/_claude-code/settings.md %})
-- [モデル設定]({% link _documents/_claude-code/model-config.md %})
+- [CLI リファレンス]({{ site.baseurl }}/documents/_claude-code/cli-reference/)
+- [設定]({{ site.baseurl }}/documents/_claude-code/settings/)
+- [モデル設定]({{ site.baseurl }}/documents/_claude-code/model-config/)
 
 #### 開発機能
-- [インタラクティブモード]({% link _documents/_claude-code/interactive-mode.md %})
-- [スラッシュコマンド]({% link _documents/_claude-code/slash-commands.md %})
-- [フック]({% link _documents/_claude-code/hooks.md %})
+- [インタラクティブモード]({{ site.baseurl }}/documents/_claude-code/interactive-mode/)
+- [スラッシュコマンド]({{ site.baseurl }}/documents/_claude-code/slash-commands/)
+- [フック]({{ site.baseurl }}/documents/_claude-code/hooks/)
 
 #### 統合・連携
-- [IDE統合]({% link _documents/_claude-code/ide-integrations.md %})
-- [ターミナル設定]({% link _documents/_claude-code/terminal-config.md %})
+- [IDE統合]({{ site.baseurl }}/documents/_claude-code/ide-integrations/)
+- [ターミナル設定]({{ site.baseurl }}/documents/_claude-code/terminal-config/)
 
 #### 監視・分析
-- [アナリティクス]({% link _documents/_claude-code/analytics.md %})
-- [ステータスライン]({% link _documents/_claude-code/statusline.md %})
-- [使用量監視]({% link _documents/_claude-code/monitoring-usage.md %})
+- [アナリティクス]({{ site.baseurl }}/documents/_claude-code/analytics/)
+- [ステータスライン]({{ site.baseurl }}/documents/_claude-code/statusline/)
+- [使用量監視]({{ site.baseurl }}/documents/_claude-code/monitoring-usage/)
 
 #### 運用・管理
-- [コスト]({% link _documents/_claude-code/costs.md %})
-- [メモリ]({% link _documents/_claude-code/memory.md %})
+- [コスト]({{ site.baseurl }}/documents/_claude-code/costs/)
+- [メモリ]({{ site.baseurl }}/documents/_claude-code/memory/)
 
 #### 法的・コンプライアンス
-- [法的・コンプライアンス]({% link _documents/_claude-code/legal-and-compliance.md %})
+- [法的・コンプライアンス]({{ site.baseurl }}/documents/_claude-code/legal-and-compliance/)
 
 ---
 
 ## 🚀 **Cursor Documentation**
 
-### [📁 セクション概要]({% link _documents/_cursor/index.md %})
+### [📁 セクション概要]({{ site.baseurl }}/documents/_cursor/index/)
 
 #### はじめに・基本
-- **[get-started/]({% link _documents/_cursor/get-started/index.md %})**
-  - [基本概念]({% link _documents/_cursor/get-started/concepts.md %})
-  - [クイックスタート]({% link _documents/_cursor/get-started/quickstart.md %})
-- [ダウンロード]({% link _documents/_cursor/downloads.md %})
+- **[get-started/]({{ site.baseurl }}/documents/_cursor/get-started/index/)**
+  - [基本概念]({{ site.baseurl }}/documents/_cursor/get-started/concepts/)
+  - [クイックスタート]({{ site.baseurl }}/documents/_cursor/get-started/quickstart/)
+- [ダウンロード]({{ site.baseurl }}/documents/_cursor/downloads/)
 
 #### AI エージェント機能
-- **[agent/]({% link _documents/_cursor/agent/index.md %})**
-  - [概要]({% link _documents/_cursor/agent/overview.md %})
-  - [モード]({% link _documents/_cursor/agent/modes.md %})
-  - [プランニング]({% link _documents/_cursor/agent/planning.md %})
-  - [レビュー]({% link _documents/_cursor/agent/review.md %})
-  - [セキュリティ]({% link _documents/_cursor/agent/security.md %})
-  - [ターミナル]({% link _documents/_cursor/agent/terminal.md %})
-  - [ツール]({% link _documents/_cursor/agent/tools.md %})
+- **[agent/]({{ site.baseurl }}/documents/_cursor/agent/index/)**
+  - [概要]({{ site.baseurl }}/documents/_cursor/agent/overview/)
+  - [モード]({{ site.baseurl }}/documents/_cursor/agent/modes/)
+  - [プランニング]({{ site.baseurl }}/documents/_cursor/agent/planning/)
+  - [レビュー]({{ site.baseurl }}/documents/_cursor/agent/review/)
+  - [セキュリティ]({{ site.baseurl }}/documents/_cursor/agent/security/)
+  - [ターミナル]({{ site.baseurl }}/documents/_cursor/agent/terminal/)
+  - [ツール]({{ site.baseurl }}/documents/_cursor/agent/tools/)
 
 #### CLI・自動化
-- **[cli/]({% link _documents/_cursor/cli/index.md %})**
-  - [概要]({% link _documents/_cursor/cli/overview.md %})
-  - [インストール]({% link _documents/_cursor/cli/installation.md %})
-  - [使用方法]({% link _documents/_cursor/cli/using.md %})
-  - [ヘッドレス実行]({% link _documents/_cursor/cli/headless.md %})
-  - [シェルモード]({% link _documents/_cursor/cli/shell-mode.md %})
-  - [GitHub Actions]({% link _documents/_cursor/cli/github-actions.md %})
-  - [MCP]({% link _documents/_cursor/cli/mcp.md %})
-  - **[reference/]({% link _documents/_cursor/cli/reference/index.md %})**
-    - [認証]({% link _documents/_cursor/cli/reference/authentication.md %})
-    - [設定]({% link _documents/_cursor/cli/reference/configuration.md %})
-    - [出力形式]({% link _documents/_cursor/cli/reference/output-format.md %})
-    - [パラメータ]({% link _documents/_cursor/cli/reference/parameters.md %})
-    - [権限]({% link _documents/_cursor/cli/reference/permissions.md %})
-    - [スラッシュコマンド]({% link _documents/_cursor/cli/reference/slash-commands.md %})
+- **[cli/]({{ site.baseurl }}/documents/_cursor/cli/index/)**
+  - [概要]({{ site.baseurl }}/documents/_cursor/cli/overview/)
+  - [インストール]({{ site.baseurl }}/documents/_cursor/cli/installation/)
+  - [使用方法]({{ site.baseurl }}/documents/_cursor/cli/using/)
+  - [ヘッドレス実行]({{ site.baseurl }}/documents/_cursor/cli/headless/)
+  - [シェルモード]({{ site.baseurl }}/documents/_cursor/cli/shell-mode/)
+  - [GitHub Actions]({{ site.baseurl }}/documents/_cursor/cli/github-actions/)
+  - [MCP]({{ site.baseurl }}/documents/_cursor/cli/mcp/)
+  - **[reference/]({{ site.baseurl }}/documents/_cursor/cli/reference/index/)**
+    - [認証]({{ site.baseurl }}/documents/_cursor/cli/reference/authentication/)
+    - [設定]({{ site.baseurl }}/documents/_cursor/cli/reference/configuration/)
+    - [出力形式]({{ site.baseurl }}/documents/_cursor/cli/reference/output-format/)
+    - [パラメータ]({{ site.baseurl }}/documents/_cursor/cli/reference/parameters/)
+    - [権限]({{ site.baseurl }}/documents/_cursor/cli/reference/permissions/)
+    - [スラッシュコマンド]({{ site.baseurl }}/documents/_cursor/cli/reference/slash-commands/)
 
 #### 設定・カスタマイズ
-- **[settings/]({% link _documents/_cursor/settings/index.md %})**
-  - [API キー]({% link _documents/_cursor/settings/api-keys.md %})
-- **[configuration/]({% link _documents/_cursor/configuration/index.md %})**
-  - [拡張機能]({% link _documents/_cursor/configuration/extensions.md %})
-  - [キーバインド]({% link _documents/_cursor/configuration/kbd.md %})
-  - [シェル]({% link _documents/_cursor/configuration/shell.md %})
-  - [テーマ]({% link _documents/_cursor/configuration/themes.md %})
+- **[settings/]({{ site.baseurl }}/documents/_cursor/settings/index/)**
+  - [API キー]({{ site.baseurl }}/documents/_cursor/settings/api-keys/)
+- **[configuration/]({{ site.baseurl }}/documents/_cursor/configuration/index/)**
+  - [拡張機能]({{ site.baseurl }}/documents/_cursor/configuration/extensions/)
+  - [キーバインド]({{ site.baseurl }}/documents/_cursor/configuration/kbd/)
+  - [シェル]({{ site.baseurl }}/documents/_cursor/configuration/shell/)
+  - [テーマ]({{ site.baseurl }}/documents/_cursor/configuration/themes/)
 
 #### コンテキスト・インデックス
-- **[context/]({% link _documents/_cursor/context/index.md %})**
-  - [コードベースインデックス]({% link _documents/_cursor/context/codebase-indexing.md %})
-  - [除外ファイル]({% link _documents/_cursor/context/ignore-files.md %})
-  - [メモリ]({% link _documents/_cursor/context/memories.md %})
-  - [ルール]({% link _documents/_cursor/context/rules.md %})
-  - [シンボル]({% link _documents/_cursor/context/symbols.md %})
+- **[context/]({{ site.baseurl }}/documents/_cursor/context/index/)**
+  - [コードベースインデックス]({{ site.baseurl }}/documents/_cursor/context/codebase-indexing/)
+  - [除外ファイル]({{ site.baseurl }}/documents/_cursor/context/ignore-files/)
+  - [メモリ]({{ site.baseurl }}/documents/_cursor/context/memories/)
+  - [ルール]({{ site.baseurl }}/documents/_cursor/context/rules/)
+  - [シンボル]({{ site.baseurl }}/documents/_cursor/context/symbols/)
 
 #### 統合・連携
-- **[integrations/]({% link _documents/_cursor/integrations/index.md %})**
-  - [ディープリンク]({% link _documents/_cursor/integrations/deeplinks.md %})
-  - [Git]({% link _documents/_cursor/integrations/git.md %})
-  - [GitHub]({% link _documents/_cursor/integrations/github.md %})
-  - [Linear]({% link _documents/_cursor/integrations/linear.md %})
-  - [Slack]({% link _documents/_cursor/integrations/slack.md %})
+- **[integrations/]({{ site.baseurl }}/documents/_cursor/integrations/index/)**
+  - [ディープリンク]({{ site.baseurl }}/documents/_cursor/integrations/deeplinks/)
+  - [Git]({{ site.baseurl }}/documents/_cursor/integrations/git/)
+  - [GitHub]({{ site.baseurl }}/documents/_cursor/integrations/github/)
+  - [Linear]({{ site.baseurl }}/documents/_cursor/integrations/linear/)
+  - [Slack]({{ site.baseurl }}/documents/_cursor/integrations/slack/)
 
 #### タブ・ワークスペース
-- **[tab/]({% link _documents/_cursor/tab/index.md %})**
-  - [概要]({% link _documents/_cursor/tab/index.md %})
+- **[tab/]({{ site.baseurl }}/documents/_cursor/tab/index/)**
+  - [概要]({{ site.baseurl }}/documents/_cursor/tab/index/)
 
 #### トラブルシューティング
-- **[troubleshooting/]({% link _documents/_cursor/troubleshooting/index.md %})**
-  - [よくある問題]({% link _documents/_cursor/troubleshooting/common-issues.md %})
-  - [リクエスト・レポート]({% link _documents/_cursor/troubleshooting/request-reporting.md %})
-  - [トラブルシューティングガイド]({% link _documents/_cursor/troubleshooting/troubleshooting-guide.md %})
+- **[troubleshooting/]({{ site.baseurl }}/documents/_cursor/troubleshooting/index/)**
+  - [よくある問題]({{ site.baseurl }}/documents/_cursor/troubleshooting/common-issues/)
+  - [リクエスト・レポート]({{ site.baseurl }}/documents/_cursor/troubleshooting/request-reporting/)
+  - [トラブルシューティングガイド]({{ site.baseurl }}/documents/_cursor/troubleshooting/troubleshooting-guide/)
 
 #### 特殊機能
-- [モデル]({% link _documents/_cursor/models.md %})
-- [BugBot]({% link _documents/_cursor/bugbot.md %})
+- [モデル]({{ site.baseurl }}/documents/_cursor/models/)
+- [BugBot]({{ site.baseurl }}/documents/_cursor/bugbot/)
 
 ---
 
 ## 🔗 **GitHub MCP Server**
 
-### [📁 セクション概要]({% link _documents/github-mcp-index.md %})
+### [📁 セクション概要]({{ site.baseurl }}/documents/github-mcp-index/)
 
 #### メインドキュメント
-- [GitHub MCP Server]({% link _documents/github-mcp-server.md %}) - 動的読み込み
+- [GitHub MCP Server]({{ site.baseurl }}/documents/github-mcp-server/) - 動的読み込み
 
 #### 実装・導入
-- [インスタント実装]({% link _documents/github-mcp-server-instant.md %})
-- [プラグイン開発]({% link _documents/github-mcp-server-plugin.md %})
+- [インスタント実装]({{ site.baseurl }}/documents/github-mcp-server-instant/)
+- [プラグイン開発]({{ site.baseurl }}/documents/github-mcp-server-plugin/)
 
 #### 技術実装
-- [iframe統合]({% link _documents/github-mcp-server-iframe.md %})
-- [リダイレクト実装]({% link _documents/github-mcp-server-redirect.md %})
+- [iframe統合]({{ site.baseurl }}/documents/github-mcp-server-iframe/)
+- [リダイレクト実装]({{ site.baseurl }}/documents/github-mcp-server-redirect/)
 
 #### 公式リソース
-- [README]({% link _documents/github-mcp-server-readme.md %})
+- [README]({{ site.baseurl }}/documents/github-mcp-server-readme/)
 
 #### 比較・分析
-- [リダイレクト手法比較]({% link _documents/redirect-comparison.md %})
+- [リダイレクト手法比較]({{ site.baseurl }}/documents/redirect-comparison/)
 
 ---
 
 ## 📖 **学習・リファレンス**
 
 ### 基本ガイド
-- [はじめに]({% link _documents/getting-started.md %})
-- [高度な機能]({% link _documents/advanced-feature.md %})
+- [はじめに]({{ site.baseurl }}/documents/getting-started/)
+- [高度な機能]({{ site.baseurl }}/documents/advanced-feature/)
 
 ### ドキュメント管理
-- [Claude Code Documentation]({% link _documents/claude-code-documentation.md %})
-- [Cursor Documentation]({% link _documents/cursor-documentation.md %})
+- [Claude Code Documentation]({{ site.baseurl }}/documents/claude-code-documentation/)
+- [Cursor Documentation]({{ site.baseurl }}/documents/cursor-documentation/)
 
 ### ナビゲーション
-- [サイトマップ]({% link _documents/site-map.md %}) - このページ
+- [サイトマップ]({{ site.baseurl }}/documents/site-map/) - このページ
 
 ---
 
@@ -202,13 +202,13 @@ layout: default
 
 ### コンテンツ概要
 
-| セクション | ドキュメント数 | 主要機能 |
-|-----------|-------------|---------|
-| **Anthropic** | 15 | プロンプトエンジニアリング・Claude 4活用 |
-| **Claude Code** | 15 | IDE統合・開発効率化・AI支援 |
-| **Cursor** | 45+ | AI統合IDE・エージェント・CLI・統合 |
-| **GitHub MCP** | 7 | GitHub統合・MCP・自動化 |
-| **基本ガイド** | 6 | 学習・リファレンス・ナビゲーション |
+| セクション      | ドキュメント数 | 主要機能                                 |
+| --------------- | -------------- | ---------------------------------------- |
+| **Anthropic**   | 15             | プロンプトエンジニアリング・Claude 4活用 |
+| **Claude Code** | 15             | IDE統合・開発効率化・AI支援              |
+| **Cursor**      | 45+            | AI統合IDE・エージェント・CLI・統合       |
+| **GitHub MCP**  | 7              | GitHub統合・MCP・自動化                  |
+| **基本ガイド**  | 6              | 学習・リファレンス・ナビゲーション       |
 
 
 ### 総計

--- a/_includes/navigation.md
+++ b/_includes/navigation.md
@@ -5,19 +5,19 @@
     <span style="color: #d0d7de;">|</span>
 
     <div style="display: flex; flex-wrap: wrap; gap: 12px;">
-      <a href="{% link _documents/_anthropic-prompt-engineering/index.md %}" style="color: #0969da; text-decoration: none;">
+      <a href="{{ site.baseurl }}/documents/_anthropic-prompt-engineering/index/" style="color: #0969da; text-decoration: none;">
         🤖 Anthropic
       </a>
 
-      <a href="{% link _documents/_claude-code/index.md %}" style="color: #0969da; text-decoration: none;">
+      <a href="{{ site.baseurl }}/documents/_claude-code/index/" style="color: #0969da; text-decoration: none;">
         💻 Claude Code
       </a>
 
-      <a href="{% link _documents/_cursor/index.md %}" style="color: #0969da; text-decoration: none;">
+      <a href="{{ site.baseurl }}/documents/_cursor/index/" style="color: #0969da; text-decoration: none;">
         🚀 Cursor
       </a>
 
-      <a href="{% link _documents/github-mcp-index.md %}" style="color: #0969da; text-decoration: none;">
+      <a href="{{ site.baseurl }}/documents/github-mcp-index/" style="color: #0969da; text-decoration: none;">
         🔗 GitHub MCP
       </a>
     </div>
@@ -25,11 +25,11 @@
     <span style="color: #d0d7de;">|</span>
 
     <div style="display: flex; flex-wrap: wrap; gap: 12px;">
-      <a href="{% link _documents/getting-started.md %}" style="color: #cf222e; text-decoration: none;">
+      <a href="{{ site.baseurl }}/documents/getting-started/" style="color: #cf222e; text-decoration: none;">
         📖 はじめに
       </a>
 
-      <a href="{% link _documents/advanced-feature.md %}" style="color: #cf222e; text-decoration: none;">
+      <a href="{{ site.baseurl }}/documents/advanced-feature/" style="color: #cf222e; text-decoration: none;">
         ⚡ 高度な機能
       </a>
     </div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,4 +1,6 @@
---- --- // GitHub Pages default styles
+---
+---
+// GitHub Pages default styles
 
 /* カスタムスタイル */
 .wrapper {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,6 +1,4 @@
----
----
-@import "minima";
+--- --- // GitHub Pages default styles
 
 /* カスタムスタイル */
 .wrapper {

--- a/index.md
+++ b/index.md
@@ -168,6 +168,7 @@ GitHub MCP Server → 基本設定
 **🎯 目標**: このサイトを通じて、開発者の皆様がAI・モダンツールを活用した効率的で高品質な開発ワークフローを構築できることを目指しています。
 
 {% assign docs_col = site.collections['documents'] %}
-{% if docs_col == nil or docs_col.docs | size == 0 %}
+{% assign docs_size = docs_col.docs | size %}
+{% if docs_col == nil or docs_size == 0 %}
 <p><em>ドキュメントがまだありません。_documentsフォルダにMarkdownファイルを追加してください。</em></p>
 {% endif %}

--- a/index.md
+++ b/index.md
@@ -16,13 +16,13 @@ AI活用・プロンプトエンジニアリング・IDE効率化・GitHub統合
 
 ### 🤖 **AI・プロンプトエンジニアリング**
 
-#### [Anthropic プロンプトエンジニアリング]({% link _documents/_anthropic-prompt-engineering/index.md %})
+#### [Anthropic プロンプトエンジニアリング]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/)
 ##### Claude 4を活用したプロンプトエンジニアリング技術
 - 基本概念からベストプラクティスまで
 - 15の専門技術・ツール・リソース
 - 公式ドキュメントへの直接リンク集
 
-#### [Claude Code Documentation]({% link _documents/claude-code-documentation.md %})
+#### [Claude Code Documentation]({{ site.baseurl }}/documents/claude-code-documentation/)
 ##### Claude Code統合開発環境での活用
 - IDE統合・コマンドリファレンス
 - アナリティクス・設定・最適化
@@ -32,7 +32,7 @@ AI活用・プロンプトエンジニアリング・IDE効率化・GitHub統合
 
 ### 🛠️ **IDE・開発環境**
 
-#### [Cursor Documentation]({% link _documents/_cursor/index.md %})
+#### [Cursor Documentation]({{ site.baseurl }}/documents/_cursor/)
 ##### 次世代AI統合IDE Cursorの完全ガイド
 - クイックスタート・基本概念
 - エージェント機能・高度な設定
@@ -42,27 +42,27 @@ AI活用・プロンプトエンジニアリング・IDE効率化・GitHub統合
 
 ### 🔗 **GitHub統合・自動化**
 
-#### [GitHub MCP Server]({% link _documents/github-mcp-index.md %})
+#### [GitHub MCP Server]({{ site.baseurl }}/documents/github-mcp-index/)
 ##### GitHubとの高度な統合ソリューション
 - リアルタイム公式ドキュメント
 - 認証・設定・実装ガイド
 - 動的コンテンツ読み込み機能
 
 #### GitHub MCP関連ツール
-- [インスタント実装]({% link _documents/github-mcp-server-instant.md %}) - 即座に使える設定
-- [プラグイン開発]({% link _documents/github-mcp-server-plugin.md %}) - カスタムプラグイン作成
-- [リダイレクト最適化]({% link _documents/github-mcp-server-redirect.md %}) - パフォーマンス向上
+- [インスタント実装]({{ site.baseurl }}/documents/github-mcp-server-instant/) - 即座に使える設定
+- [プラグイン開発]({{ site.baseurl }}/documents/github-mcp-server-plugin/) - カスタムプラグイン作成
+- [リダイレクト最適化]({{ site.baseurl }}/documents/github-mcp-server-redirect/) - パフォーマンス向上
 
 ---
 
 ### 📖 **学習・リファレンス**
 
-#### [はじめに]({% link _documents/getting-started.md %})
+#### [はじめに]({{ site.baseurl }}/documents/getting-started/)
 ##### このサイトの基本的な使い方
 - セットアップ手順・ナビゲーション
 - 各セクションの概要・活用方法
 
-#### [高度な機能]({% link _documents/advanced-feature.md %})
+#### [高度な機能]({{ site.baseurl }}/documents/advanced-feature/)
 ##### 発展的な技術・実装パターン
 - 上級者向けテクニック
 - 複合的なワークフロー構築
@@ -119,13 +119,13 @@ GitHub MCP Server → 基本設定
 
 ## 📊 **コンテンツ統計**
 
-| カテゴリ | ドキュメント数 | 主要機能 |
-|---------|-------------|---------|
-| **Anthropic** | 15ファイル | プロンプトエンジニアリング・Claude 4活用 |
-| **Claude Code** | 14ファイル | IDE統合・開発効率化 |
-| **Cursor** | 32+ファイル | AI統合IDE・エージェント機能 |
-| **GitHub MCP** | 7ファイル | GitHub統合・自動化・MCP |
-| **その他** | 4ファイル | 基本設定・高度機能・学習ガイド |
+| カテゴリ        | ドキュメント数 | 主要機能                                 |
+| --------------- | -------------- | ---------------------------------------- |
+| **Anthropic**   | 15ファイル     | プロンプトエンジニアリング・Claude 4活用 |
+| **Claude Code** | 14ファイル     | IDE統合・開発効率化                      |
+| **Cursor**      | 32+ファイル    | AI統合IDE・エージェント機能              |
+| **GitHub MCP**  | 7ファイル      | GitHub統合・自動化・MCP                  |
+| **その他**      | 4ファイル      | 基本設定・高度機能・学習ガイド           |
 
 **総計**: **70+ドキュメント** で包括的な開発者向けリソースを提供
 
@@ -134,19 +134,19 @@ GitHub MCP Server → 基本設定
 ## 🔍 **おすすめナビゲーション**
 
 ### 🆕 **初心者の方**
-1. [はじめに]({% link _documents/getting-started.md %}) - サイト全体の使い方
-2. [Cursor クイックスタート]({% link _documents/_cursor/get-started/quickstart.md %}) - AI IDE入門
-3. [Claude 4 ベストプラクティス]({% link _documents/_anthropic-prompt-engineering/claude-4-best-practices.md %}) - AI活用基礎
+1. [はじめに]({{ site.baseurl }}/documents/getting-started/) - サイト全体の使い方
+2. [Cursor クイックスタート]({{ site.baseurl }}/documents/_cursor/get-started/quickstart/) - AI IDE入門
+3. [Claude 4 ベストプラクティス]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/claude-4-best-practices/) - AI活用基礎
 
 ### ⚡ **効率化重視の方**
-1. [Cursor エージェント機能]({% link _documents/_cursor/agent/overview.md %}) - AI支援開発
-2. [プロンプトテンプレート]({% link _documents/_anthropic-prompt-engineering/prompt-templates-and-variables.md %}) - 再利用可能な技術
-3. [GitHub Actions統合]({% link _documents/_cursor/cli/github-actions.md %}) - CI/CD自動化
+1. [Cursor エージェント機能]({{ site.baseurl }}/documents/_cursor/agent/overview/) - AI支援開発
+2. [プロンプトテンプレート]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/prompt-templates-and-variables/) - 再利用可能な技術
+3. [GitHub Actions統合]({{ site.baseurl }}/documents/_cursor/cli/github-actions/) - CI/CD自動化
 
 ### 🔧 **上級者の方**
-1. [高度な機能]({% link _documents/advanced-feature.md %}) - 発展的技術
-2. [GitHub MCP Server]({% link _documents/github-mcp-index.md %}) - 深度統合
-3. [拡張思考のコツ]({% link _documents/_anthropic-prompt-engineering/extended-thinking-tips.md %}) - AI最適化
+1. [高度な機能]({{ site.baseurl }}/documents/advanced-feature/) - 発展的技術
+2. [GitHub MCP Server]({{ site.baseurl }}/documents/github-mcp-index/) - 深度統合
+3. [拡張思考のコツ]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/extended-thinking-tips/) - AI最適化
 
 ---
 


### PR DESCRIPTION
- _config.yml: サイト基本情報を追加し、SEOプラグインを設定
- Gemfile: GitHub Pagesで利用可能なプラグインの説明を更新
- index.md: ドキュメントリンクを{{ site.baseurl }}形式に統一し、可読性を向上
- _documents/_anthropic-prompt-engineering/index.md: コンテンツ一覧を整理し、初心者向けの学習パスを追加