### PR TITLE
🔧 ドキュメントのパーマリンクとインクルード設定の更新

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ author:
 collections:
   documents:
     output: true
-    permalink: /documents/:name/
+    permalink: /documents/:path/
 defaults:
   - scope:
       path: "_documents"
@@ -71,6 +71,12 @@ sitemap:
 markdown: kramdown
 highlighter: rouge
 incremental: false
+
+# インクルード設定（アンダースコアで始まるディレクトリを明示的に含める）
+include:
+  - _documents/_anthropic-prompt-engineering
+  - _documents/_claude-code
+  - _documents/_cursor
 
 # 除外ファイル設定
 exclude:

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ AI活用・プロンプトエンジニアリング・IDE効率化・GitHub統合
 
 ### 🤖 **AI・プロンプトエンジニアリング**
 
-#### [Anthropic プロンプトエンジニアリング]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/index/)
+#### [Anthropic プロンプトエンジニアリング]({{ site.baseurl }}/documents/_anthropic-prompt-engineering/)
 ##### Claude 4を活用したプロンプトエンジニアリング技術
 - 基本概念からベストプラクティスまで
 - 15の専門技術・ツール・リソース
@@ -30,7 +30,7 @@ AI活用・プロンプトエンジニアリング・IDE効率化・GitHub統合
 
 ### 🛠️ **IDE・開発環境**
 
-#### [Cursor Documentation]({{ site.baseurl }}/documents/_cursor/index/)
+#### [Cursor Documentation]({{ site.baseurl }}/documents/_cursor/)
 ##### 次世代AI統合IDE Cursorの完全ガイド
 - クイックスタート・基本概念
 - エージェント機能・高度な設定


### PR DESCRIPTION
- _config.yml: ドキュメントのパーマリンクを`:name`から`:path`に変更し、特定のディレクトリをインクルードする設定を追加。
- index.md: AnthropicプロンプトエンジニアリングとCursor Documentationのリンクを修正し、末尾の`/index/`を削除。

改善内容: ドキュメントのリンク整備とインクルード設定の明確化。