### PR TITLE
Fix 404 links on homepage and navigation

### DIFF
--- a/_documents/claude-code-documentation.md
+++ b/_documents/claude-code-documentation.md
@@ -1,3 +1,9 @@
+---
+title: Claude Code 総合ドキュメント
+description: Claude Codeの開発環境設定・統合・活用のための包括的ガイド
+layout: default
+---
+
 # Claude Code 総合ドキュメント
 
 ## 目次

--- a/_documents/cursor/index.md
+++ b/_documents/cursor/index.md
@@ -3,6 +3,7 @@ title: Cursor Documentation
 description: AI統合IDE Cursorの包括的ドキュメント・ガイド集
 order: 0
 layout: default
+permalink: /documents/cursor/
 ---
 
 # 🚀 Cursor Documentation

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
           <li><a href="{{ '/' | relative_url }}">ホーム</a></li>
           <li><a href="{{ '/documents/anthropic-prompt-engineering/' | relative_url }}">AI・プロンプト</a></li>
           <li><a href="{{ '/documents/cursor/' | relative_url }}">Cursor</a></li>
-          <li><a href="{{ '/documents/github-mcp-index.html' | relative_url }}">GitHub MCP</a></li>
+          <li><a href="{{ '/documents/github-mcp-index/' | relative_url }}">GitHub MCP</a></li>
         </ul>
       </nav>
       {% endif %}


### PR DESCRIPTION
## 概要
トップページおよびナビゲーションメニューからアクセスした際に 404 エラーとなるリンクを修正しました。

## 変更内容
1. **Claude Code ドキュメント**: Front Matter が欠落していたため追加し、ページが正しく生成されるように修正。
2. **Cursor ドキュメント**:  を明示的に設定し、リンク切れを解消。
3. **ナビゲーション (Default Layout)**: GitHub MCP へのリンクが  付きでハードコードされていたため、正しいパス形式に修正。

## 影響範囲
- トップページのリンク
- ヘッダーナビゲーション

## テスト
- [x] ローカルでのビルド確認 (Jekyll)
- [x] 修正後のパス確認